### PR TITLE
Use relative path

### DIFF
--- a/frontend/etcdbrowser.js
+++ b/frontend/etcdbrowser.js
@@ -2,8 +2,8 @@
 var app = angular.module("app", ["xeditable","ngCookies"]);
 
 app.controller('NodeCtrl', ['$scope','$http','$cookies', function($scope,$http,$cookies) {
-  var keyPrefix = '/v2/keys',
-      statsPrefix = '/v2/stats';
+  var keyPrefix = 'v2/keys',
+      statsPrefix = 'v2/stats';
 
   if($cookies.urlPrefix){
     $scope.urlPrefix = $cookies.urlPrefix;
@@ -12,8 +12,7 @@ app.controller('NodeCtrl', ['$scope','$http','$cookies', function($scope,$http,$
   }
 
   $scope.getPrefix = function() {
-    splitted = $scope.urlPrefix.split("/")
-    return splitted[0] + "//" + splitted[2]
+    return '';
   }
 
 


### PR DESCRIPTION
I usually put etcd-browser behind nginx. If you want to use nginx reverse proxy ability, your website should use relative path instead of absolute path.
